### PR TITLE
Fix failing architecture and skills security checks

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,7 +15,7 @@ overrides:
   ip-address@<=10.3.0: 10.3.1
   js-yaml: 4.3.1
   linkify-it: 5.0.2
-  nanoid@<3.3.17: 3.3.17
+  nanoid@<3.3.18: 3.3.18
   prosemirror-model: 1.25.11
   postcss@<=8.5.17: 8.5.23
   sharp: 0.35.3
@@ -7944,11 +7944,6 @@ packages:
   mute-stream@4.0.0:
     resolution: {integrity: sha512-gSrprq0fJ3EiOErzjdIZrjysVVmJ4uu1QWfCDss5LypA5OXvrMje5Ym5z6V6RLyJ2eF87lasX7t6a0AnFvZblg==}
     engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
-
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
 
   nanoid@3.3.18:
     resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
@@ -16633,7 +16628,7 @@ snapshots:
       expo-symbols: 56.0.6(expo-font@56.0.7)(expo@56.0.14)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.2.3))(react@19.2.3)
       fast-deep-equal: 3.1.3
       invariant: 2.2.4
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       query-string: 7.1.3
       react: 19.2.3
       react-fast-compare: 3.2.2
@@ -18036,8 +18031,6 @@ snapshots:
 
   mute-stream@4.0.0: {}
 
-  nanoid@3.3.17: {}
-
   nanoid@3.3.18: {}
 
   natural-compare@1.4.0: {}
@@ -18372,7 +18365,7 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -24,7 +24,7 @@ overrides:
   "ip-address@<=10.3.0": "10.3.1"
   js-yaml: "4.3.1"
   linkify-it: "5.0.2"
-  "nanoid@<3.3.17": "3.3.17"
+  "nanoid@<3.3.18": "3.3.18"
   prosemirror-model: "1.25.11"
   "postcss@<=8.5.17": "8.5.23"
   sharp: "0.35.3"

--- a/src/work/home-query-service.ts
+++ b/src/work/home-query-service.ts
@@ -1,14 +1,19 @@
 import type { WorkHomeResponse } from '@xopcai/gateway-contract';
 
 import { listGatewayAgents } from '../gateway/agents-admin.js';
-import type { GatewayService } from '../gateway/service.js';
 import { getTunnelService } from '../tunnel/index.js';
 import {
   DEFAULT_AUTOMATION_TIMEOUT_SECONDS,
   type Automation,
   type AutomationRun,
 } from '../automations/index.js';
+import type { AutomationService } from '../automations/service/automation-service.js';
+import type { Config } from '../config/schema.js';
 import { GoalService, type GoalWithDetails } from '../goals/index.js';
+import type { NotesService } from '../notes/service.js';
+import type { ProactiveInboxService } from '../proactive/inbox/service.js';
+import type { ProjectService } from '../projects/project-service.js';
+import type { SessionIndex } from '../session/manager.js';
 import {
   isHomeAttentionAcknowledged,
   getRelationshipSettings,
@@ -16,6 +21,7 @@ import {
   type HomeAttentionSubjectKind,
 } from '../storage/sqlite/index.js';
 import type { WorkflowRunSummary } from '../workflows/domain/index.js';
+import type { WorkflowRunService } from '../workflows/service/workflow-run-service.js';
 import { WorkItemService } from '../work-items/index.js';
 import { OutcomeReceiptService } from './outcome-receipt-service.js';
 import { OutcomeRepository } from './outcome-repository.js';
@@ -62,6 +68,25 @@ type HomeSnapshot = WorkHomeResponse & {
   gateway: Record<string, unknown>;
   recentAutomationRuns: HomeAutomationRun[];
 };
+
+interface WorkHomeGatewayPort {
+  readonly notesServiceInstance: NotesService;
+  readonly sessions: Pick<SessionIndex, 'listSessions'> & {
+    getActiveRun(sessionKey: string): { active: boolean; runId?: string };
+  };
+  readonly currentConfig: Config;
+  readonly automationServiceInstance: AutomationService;
+  readonly projects: ProjectService;
+  readonly proactiveInbox: ProactiveInboxService;
+  createWorkflowRunService(): WorkflowRunService;
+  getHealth(): {
+    status: string;
+    ready: boolean;
+    httpListening: boolean;
+    version: string;
+    uptime: number;
+  };
+}
 
 export function workItemAttentionRank(
   item: { status: string; dueAt?: number; priority: string; updatedAt: number },
@@ -274,7 +299,7 @@ export class WorkHomeQueryService {
   readonly #outcomes = new OutcomeRepository();
   readonly #attentionGovernor = new AttentionGovernor();
 
-  constructor(private readonly service: GatewayService) {}
+  constructor(private readonly service: WorkHomeGatewayPort) {}
 
   async getSnapshot(locale?: string): Promise<HomeSnapshot> {
     const notes = this.service.notesServiceInstance;


### PR DESCRIPTION
## What changed

- Replace the `WorkHomeQueryService` dependency on the concrete `GatewayService` with a narrow structural gateway port.
- Raise the pnpm `nanoid` override to `3.3.18` and refresh the lockfile.

## Why

The latest CI run reported 32 dependency-cruiser cycles because the work layer imported the gateway composition root. The latest Skills Test run also failed its production dependency audit because transitive Expo/PostCSS paths resolved `nanoid@3.3.17`, which is affected by GHSA-2v37-7h3g-55p8.

## Impact

The home query service keeps the same runtime behavior while no longer creating a work-to-gateway architecture edge. Production dependency resolution now uses the patched nanoid release.

## Validation

- `pnpm run depcheck`
- `pnpm audit --prod --audit-level=high`
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run dev -- skills test security --deep`
- `pnpm vitest run src/gateway/hono/routes/__tests__/home-briefing.test.ts`
- `pnpm run build:ci`
- `pnpm install --frozen-lockfile --offline`
- `git diff --check`
