### PR TITLE
feat(history): export sessions for ctx

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -125,6 +125,7 @@ export default defineConfig({
             text: 'Reference',
             items: [
               { text: 'CLI commands', link: '/cli' },
+              { text: 'Export history to ctx', link: '/ctx-history' },
               { text: 'Configuration reference', link: '/reference/configuration' },
               { text: 'Data and file locations', link: '/workspace' },
               { text: 'Tool runtimes', link: '/runtime-tools' },
@@ -223,6 +224,7 @@ export default defineConfig({
             text: '参考',
             items: [
               { text: 'CLI 命令', link: '/zh/cli' },
+              { text: '导出历史到 ctx', link: '/zh/ctx-history' },
               { text: '配置参考', link: '/zh/reference/configuration' },
               { text: '数据与文件位置', link: '/zh/workspace' },
               { text: '工具运行环境', link: '/zh/runtime-tools' },

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -27,6 +27,7 @@ Global options such as `--config <path>` and `--workspace <path>` select a diffe
 | `resume` | Resume a previous TUI Session |
 | `tunnel` | Manage public tunnel access |
 | `gateway` | Run and manage the Gateway |
+| `history` | Export Session history for external tools such as ctx |
 | `session` | List and manage Sessions |
 | `project` | Manage long-running Projects |
 | `doctor` | Diagnose installation, data, and security issues |
@@ -71,6 +72,8 @@ xopc config validate
 xopc doctor
 xopc logs tail
 ```
+
+To make XOPC Sessions searchable in ctx, see [Export history to ctx](./ctx-history.md).
 
 ## Profiles and paths
 

--- a/docs/ctx-history.md
+++ b/docs/ctx-history.md
@@ -1,0 +1,31 @@
+# Export history to ctx
+
+XOPC can export its Sessions as a provider-owned [`ctx-history-jsonl-v2`](https://github.com/ctxrs/ctx/blob/main/docs/custom-history-import-format.md) source. ctx imports this durable file through its history-source plugin contract; it does not read the XOPC database directly.
+
+## Export and import
+
+```bash
+xopc history export ctx
+ctx import --history-source-manifest ~/.xopc/exports/ctx/ctx-history-plugin.json
+```
+
+The export creates:
+
+- `~/.xopc/exports/ctx/history.jsonl` — the durable history source;
+- `~/.xopc/exports/ctx/ctx-history-plugin.json` — the ctx plugin manifest.
+
+After the first import, search only XOPC history with:
+
+```bash
+ctx search "release decision" --history-source xopc/default
+```
+
+Run `xopc history export ctx` again when XOPC history changes. The output is deterministic and is not rewritten when its contents are unchanged. A registered ctx daemon watches the durable source for later file changes.
+
+Use `--output-dir <path>` to choose another directory, or `--json` for script-friendly result metadata.
+
+## Export boundary
+
+The exporter includes visible user and assistant messages, tool calls and outputs, local command activity, and compaction summaries. It deliberately excludes hidden context rows, system prompts, model reasoning blocks, invisible extension messages, and deleted Sessions. Each reset generation keeps its own stable XOPC Session ID.
+
+The export is explicit; XOPC does not run it in the background. Newly created output directories and exported files use private permissions (`0700` and `0600`) on platforms that support POSIX modes. Review the JSONL before importing it if a Session may contain sensitive text.

--- a/docs/zh/cli.md
+++ b/docs/zh/cli.md
@@ -27,6 +27,7 @@ xopc --version
 | `resume` | 恢复之前的 TUI Session |
 | `tunnel` | 管理公网隧道访问 |
 | `gateway` | 运行和管理 Gateway |
+| `history` | 为 ctx 等外部工具导出 Session 历史 |
 | `session` | 列出和管理 Session |
 | `project` | 管理长期 Project |
 | `doctor` | 诊断安装、数据和安全问题 |
@@ -71,6 +72,8 @@ xopc config validate
 xopc doctor
 xopc logs tail
 ```
+
+如需在 ctx 中搜索 XOPC Session，请参阅[导出历史到 ctx](./ctx-history.md)。
 
 ## Profile 与路径
 

--- a/docs/zh/ctx-history.md
+++ b/docs/zh/ctx-history.md
@@ -1,0 +1,31 @@
+# 导出历史到 ctx
+
+XOPC 可以把 Session 导出为由自身维护的 [`ctx-history-jsonl-v2`](https://github.com/ctxrs/ctx/blob/main/docs/custom-history-import-format.md) 数据源。ctx 通过 history-source 插件协议导入这个持久文件，不会直接读取 XOPC 数据库。
+
+## 导出与导入
+
+```bash
+xopc history export ctx
+ctx import --history-source-manifest ~/.xopc/exports/ctx/ctx-history-plugin.json
+```
+
+导出会生成：
+
+- `~/.xopc/exports/ctx/history.jsonl`：持久历史数据源；
+- `~/.xopc/exports/ctx/ctx-history-plugin.json`：ctx 插件清单。
+
+首次导入后，可以只搜索 XOPC 历史：
+
+```bash
+ctx search "发布决策" --history-source xopc/default
+```
+
+XOPC 历史变化后，再次运行 `xopc history export ctx`。导出结果是确定性的；内容没有变化时不会重写文件。ctx 的持久 daemon 注册数据源后，会监视这个文件的后续变化。
+
+可用 `--output-dir <path>` 指定其他目录，或用 `--json` 获取便于脚本处理的结果。
+
+## 导出边界
+
+导出内容包括可见的用户与助手消息、工具调用与输出、本地命令活动以及压缩摘要。隐藏上下文、system prompt、模型 reasoning、不可见扩展消息和已删除 Session 不会导出。每次重置产生的会话 generation 保留各自稳定的 XOPC Session ID。
+
+导出只在用户显式执行命令时发生，XOPC 不会在后台自动运行。支持 POSIX 权限的平台上，新建输出目录和导出文件的权限分别为 `0700` 和 `0600`。如果 Session 可能含有敏感文本，请在导入前检查 JSONL。

--- a/src/cli/command-loaders.ts
+++ b/src/cli/command-loaders.ts
@@ -25,6 +25,7 @@ export const REGISTRY_COMMAND_MODULES: Record<string, CommandLoader> = {
   tui: () => import('./commands/tui.js'),
   resume: () => import('./commands/resume.js'),
   gateway: () => import('./commands/gateway.js'),
+  history: () => import('./commands/history.js'),
   session: () => import('./commands/session.js'),
   project: () => import('./commands/project.js'),
   config: () => import('./commands/config.js'),

--- a/src/cli/command-manifest.ts
+++ b/src/cli/command-manifest.ts
@@ -30,6 +30,7 @@ export const ROOT_HELP_COMMANDS: RootHelpCommand[] = [
   { name: 'resume [options] [sessionKey]', description: 'Resume a previous TUI session' },
   { name: 'tunnel', description: 'Manage FRP remote access tunnel' },
   { name: 'gateway [options]', description: 'Start the xopc gateway server' },
+  { name: 'history', description: 'Export XOPC session history for external tools' },
   { name: 'session', description: 'Session management commands' },
   { name: 'project', description: 'Manage long-running projects' },
   { name: 'doctor [options]', description: 'Check xopc installation health and diagnose common issues' },

--- a/src/cli/commands/history.ts
+++ b/src/cli/commands/history.ts
@@ -1,0 +1,63 @@
+import { Command } from 'commander';
+
+import { exportCtxHistory } from '../../history/ctx/exporter.js';
+import { requireXopcDatabase } from '../../storage/sqlite/index.js';
+import { formatExamples, register, type CLIContext } from '../registry.js';
+
+interface ExportCtxOptions {
+  outputDir?: string;
+  json?: boolean;
+}
+
+async function runCtxExport(options: ExportCtxOptions): Promise<void> {
+  try {
+    const { db } = requireXopcDatabase();
+    const result = await exportCtxHistory(db, { outputDir: options.outputDir });
+    const importCommand = `ctx import --history-source-manifest ${result.manifestPath}`;
+    if (options.json) {
+      console.log(JSON.stringify({ ...result, importCommand }, null, 2));
+      return;
+    }
+
+    const action = result.changed ? 'Exported' : 'Already up to date';
+    console.log(`${action}: ${result.sessionCount} sessions, ${result.eventCount} events`);
+    console.log(`History: ${result.historyPath}`);
+    console.log(`Manifest: ${result.manifestPath}`);
+    console.log(`\nRegister or refresh it in ctx:\n  ${importCommand}`);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`Failed to export history for ctx: ${message}`);
+    process.exit(1);
+  }
+}
+
+function createHistoryCommand(_ctx: CLIContext): Command {
+  const command = new Command('history')
+    .description('Export XOPC session history for external tools')
+    .addHelpText('after', formatExamples([
+      'xopc history export ctx',
+      'xopc history export ctx --output-dir ./xopc-ctx-history',
+      'xopc history export ctx --json',
+    ]));
+  const exportCommand = command
+    .command('export')
+    .description('Export session history');
+  exportCommand
+    .command('ctx')
+    .description('Export a provider-owned ctx-history-jsonl-v2 source')
+    .option('--output-dir <path>', 'Output directory (default: <xopc-state>/exports/ctx)')
+    .option('--json', 'Output the result as JSON')
+    .action(runCtxExport);
+  return command;
+}
+
+register({
+  id: 'history',
+  name: 'history',
+  description: 'Export XOPC session history for external tools',
+  factory: createHistoryCommand,
+  metadata: {
+    category: 'utility',
+    examples: ['xopc history export ctx'],
+  },
+});

--- a/src/history/ctx/__tests__/exporter.test.ts
+++ b/src/history/ctx/__tests__/exporter.test.ts
@@ -1,0 +1,92 @@
+import { readFile, stat } from 'node:fs/promises';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { DatabaseSync } from 'node:sqlite';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  appendTranscriptEntry,
+  closeXopcDatabase,
+  deleteSessionRecord,
+  ensureSessionRecord,
+  openXopcDatabase,
+  resetSessionRecord,
+  resetXopcDatabaseSingletonForTest,
+} from '../../../storage/sqlite/index.js';
+import { exportCtxHistory } from '../exporter.js';
+
+describe('exportCtxHistory', () => {
+  let stateDir: string;
+  let outputDir: string;
+  let db: DatabaseSync;
+
+  beforeEach(() => {
+    stateDir = mkdtempSync(join(tmpdir(), 'xopc-ctx-export-'));
+    outputDir = join(stateDir, 'export');
+    resetXopcDatabaseSingletonForTest();
+    db = openXopcDatabase({ path: join(stateDir, 'xopc.db') }).db;
+  });
+
+  afterEach(() => {
+    closeXopcDatabase();
+    resetXopcDatabaseSingletonForTest();
+    rmSync(stateDir, { recursive: true, force: true });
+  });
+
+  it('exports reset generations deterministically and excludes deleted session keys', async () => {
+    const first = ensureSessionRecord('agent:main:test', '/workspace', {
+      agentId: 'main',
+      sessionType: 'chat',
+    });
+    appendTranscriptEntry('agent:main:test', { role: 'user', content: 'first generation' });
+    const reset = resetSessionRecord('agent:main:test', '/workspace');
+    expect(reset?.previousSessionId).toBe(first.sessionId);
+    appendTranscriptEntry('agent:main:test', { role: 'assistant', content: 'second generation' });
+
+    const firstExport = await exportCtxHistory(db, { outputDir });
+    const firstContents = await readFile(firstExport.historyPath, 'utf8');
+    const firstMtime = (await stat(firstExport.historyPath)).mtimeMs;
+    const secondExport = await exportCtxHistory(db, { outputDir });
+
+    expect(firstExport).toMatchObject({ sessionCount: 2, eventCount: 2, changed: true });
+    expect(secondExport.changed).toBe(false);
+    expect(await readFile(secondExport.historyPath, 'utf8')).toBe(firstContents);
+    expect((await stat(secondExport.historyPath)).mtimeMs).toBe(firstMtime);
+
+    expect(deleteSessionRecord('agent:main:test')).toBe(true);
+    const afterDelete = await exportCtxHistory(db, { outputDir });
+    expect(afterDelete).toMatchObject({ sessionCount: 0, eventCount: 0, changed: true });
+  });
+
+  it('keeps the last valid export when a transcript payload is malformed', async () => {
+    const session = ensureSessionRecord('agent:main:test', '/workspace', { agentId: 'main' });
+    appendTranscriptEntry('agent:main:test', { role: 'user', content: 'valid history' });
+    const initial = await exportCtxHistory(db, { outputDir });
+    const validContents = await readFile(initial.historyPath, 'utf8');
+
+    db.prepare(
+      `INSERT INTO transcript_entries
+       (entry_id, session_id, seq, entry_kind, role, payload_json, created_at)
+       VALUES (?, ?, ?, 'message', 'user', ?, ?)`,
+    ).run('broken-entry', session.sessionId, 2, '{not-json', Date.now());
+
+    await expect(exportCtxHistory(db, { outputDir })).rejects.toThrow(
+      'Invalid transcript payload for entry broken-entry',
+    );
+    expect(await readFile(initial.historyPath, 'utf8')).toBe(validContents);
+  });
+
+  it('writes private files and uses the configured state directory by default', async () => {
+    const result = await exportCtxHistory(db, {
+      env: { XOPC_STATE_DIR: stateDir },
+    });
+
+    expect(result.outputDir).toBe(join(stateDir, 'exports', 'ctx'));
+    if (process.platform !== 'win32') {
+      expect((await stat(result.historyPath)).mode & 0o777).toBe(0o600);
+      expect((await stat(result.manifestPath)).mode & 0o777).toBe(0o600);
+      expect((await stat(result.outputDir)).mode & 0o777).toBe(0o700);
+    }
+  });
+});

--- a/src/history/ctx/__tests__/format.test.ts
+++ b/src/history/ctx/__tests__/format.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildCtxHistoryJsonl,
+  buildCtxPluginManifest,
+  CTX_HISTORY_SCHEMA_VERSION,
+  CTX_PROVIDER_KEY,
+  CTX_SOURCE_FORMAT,
+  CTX_SOURCE_ID,
+  type XopcHistorySession,
+} from '../format.js';
+
+function parseJsonl(contents: string): Array<Record<string, unknown>> {
+  return contents.trimEnd().split('\n').map((line) => JSON.parse(line) as Record<string, unknown>);
+}
+
+function sessionWithEntries(payloads: unknown[]): XopcHistorySession {
+  return {
+    sessionId: 'session-1',
+    status: 'active',
+    createdAt: Date.parse('2026-08-01T10:00:00Z'),
+    archivedAt: null,
+    cwd: '/workspace/xopc',
+    agentId: 'main',
+    sessionType: 'chat',
+    entries: payloads.map((payload, index) => ({
+      entryId: `entry-${index + 1}`,
+      seq: index + 1,
+      createdAt: Date.parse(`2026-08-01T10:00:${String(index + 1).padStart(2, '0')}Z`),
+      payloadJson: JSON.stringify(payload),
+    })),
+  };
+}
+
+describe('ctx history format', () => {
+  it('exports visible conversation, tool, command, and summary events without hidden context or reasoning', () => {
+    const history = buildCtxHistoryJsonl([sessionWithEntries([
+      { role: 'user', content: 'ship the exporter' },
+      { kind: 'context', text: 'private injected context' },
+      { role: 'system', content: 'private system prompt' },
+      {
+        role: 'assistant',
+        content: [
+          { type: 'thinking', thinking: 'private chain of thought' },
+          { type: 'text', text: 'I will implement it.' },
+          { type: 'toolCall', id: 'call-1', name: 'read_file', arguments: { path: 'README.md' } },
+        ],
+      },
+      {
+        role: 'toolResult',
+        toolCallId: 'call-1',
+        toolName: 'read_file',
+        content: [{ type: 'text', text: 'file contents' }],
+        isError: false,
+      },
+      { role: 'bashExecution', command: 'pnpm test', output: 'all tests passed', exitCode: 0 },
+      { role: 'custom', display: false, content: 'hidden extension message' },
+      {
+        type: 'compaction',
+        summary: 'The exporter design is settled.',
+        messages: [{ role: 'user', content: 'private compacted content' }],
+      },
+    ])]);
+    const records = parseJsonl(history.contents);
+    const events = records.filter((record) => record.record_type === 'event');
+    const serialized = JSON.stringify(records);
+
+    expect(records[0]).toEqual({
+      record_type: 'manifest',
+      schema_version: CTX_HISTORY_SCHEMA_VERSION,
+      producer: 'xopc',
+    });
+    expect(records[1]).toEqual({
+      record_type: 'source',
+      source_id: CTX_SOURCE_ID,
+      provider_key: CTX_PROVIDER_KEY,
+      source_format: CTX_SOURCE_FORMAT,
+    });
+    expect(events.map((event) => event.event_type)).toEqual([
+      'message',
+      'message',
+      'tool_call',
+      'tool_output',
+      'command_started',
+      'command_output',
+      'command_finished',
+      'summary',
+    ]);
+    expect(serialized).toContain('ship the exporter');
+    expect(serialized).toContain('read_file');
+    expect(serialized).toContain('all tests passed');
+    expect(serialized).toContain('The exporter design is settled.');
+    expect(serialized).not.toContain('private injected context');
+    expect(serialized).not.toContain('private system prompt');
+    expect(serialized).not.toContain('private chain of thought');
+    expect(serialized).not.toContain('hidden extension message');
+    expect(serialized).not.toContain('private compacted content');
+    expect(new Set(events.map((event) => event.event_id)).size).toBe(events.length);
+    expect(events.map((event) => event.event_index)).toEqual([
+      65_536,
+      262_144,
+      262_145,
+      327_680,
+      393_216,
+      393_217,
+      393_218,
+      524_288,
+    ]);
+  });
+
+  it('chunks large UTF-8 text while keeping every physical line below the ctx limit', () => {
+    const text = '🙂'.repeat(300_000);
+    const history = buildCtxHistoryJsonl([sessionWithEntries([{ role: 'user', content: text }])]);
+    const records = parseJsonl(history.contents);
+    const events = records.filter((record) => record.record_type === 'event');
+    const restored = events
+      .map((event) => (event.payload as { text: string }).text)
+      .join('');
+
+    expect(events).toHaveLength(2);
+    expect(restored).toBe(text);
+    for (const line of history.contents.trimEnd().split('\n')) {
+      expect(Buffer.byteLength(line, 'utf8')).toBeLessThanOrEqual(16 * 1024 * 1024);
+    }
+  });
+
+  it('builds a relative, provider-owned ctx plugin manifest', () => {
+    expect(JSON.parse(buildCtxPluginManifest())).toEqual({
+      schema_version: 1,
+      name: 'xopc',
+      display_name: 'XOPC history',
+      version: '1.0.0',
+      history_sources: [{
+        id: 'default',
+        provider_key: 'xopc',
+        source_id: 'default',
+        source_format: 'xopc-session-history-v1',
+        path: 'history.jsonl',
+        enabled: true,
+        refresh: 'manual',
+      }],
+    });
+  });
+});

--- a/src/history/ctx/exporter.ts
+++ b/src/history/ctx/exporter.ts
@@ -1,0 +1,137 @@
+import { mkdir, readFile } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+import type { DatabaseSync } from 'node:sqlite';
+
+import { resolveStateDir } from '../../config/paths-state.js';
+import { writeTextAtomic } from '../../infra/write-file-atomic.js';
+import {
+  buildCtxHistoryJsonl,
+  buildCtxPluginManifest,
+  type XopcHistoryEntry,
+  type XopcHistorySession,
+} from './format.js';
+
+interface TranscriptRow {
+  session_id: string;
+  status: string;
+  created_at: number;
+  archived_at: number | null;
+  cwd: string;
+  agent_id: string;
+  session_type: string | null;
+}
+
+interface EntryRow {
+  entry_id: string;
+  session_id: string;
+  seq: number;
+  payload_json: string;
+  created_at: number;
+}
+
+export interface CtxHistoryExportResult {
+  outputDir: string;
+  historyPath: string;
+  manifestPath: string;
+  sessionCount: number;
+  eventCount: number;
+  changed: boolean;
+}
+
+function readSnapshot(db: DatabaseSync): XopcHistorySession[] {
+  db.exec('BEGIN');
+  try {
+    const transcripts = db.prepare(
+      `SELECT
+         t.session_id,
+         t.status,
+         t.created_at,
+         t.archived_at,
+         t.cwd,
+         s.agent_id,
+         s.session_type
+       FROM transcripts t
+       JOIN sessions s ON s.session_key = t.session_key
+       WHERE t.status = 'active' OR t.archive_reason IN ('reset', 'stale')
+       ORDER BY t.created_at ASC, t.session_id ASC`,
+    ).all() as unknown as TranscriptRow[];
+    const entries = db.prepare(
+      `SELECT e.entry_id, e.session_id, e.seq, e.payload_json, e.created_at
+       FROM transcript_entries e
+       JOIN transcripts t ON t.session_id = e.session_id
+       JOIN sessions s ON s.session_key = t.session_key
+       WHERE t.status = 'active' OR t.archive_reason IN ('reset', 'stale')
+       ORDER BY t.created_at ASC, t.session_id ASC, e.seq ASC, e.entry_id ASC`,
+    ).all() as unknown as EntryRow[];
+    db.exec('COMMIT');
+
+    const entriesBySession = new Map<string, XopcHistoryEntry[]>();
+    for (const entry of entries) {
+      const bucket = entriesBySession.get(entry.session_id) ?? [];
+      bucket.push({
+        entryId: entry.entry_id,
+        seq: entry.seq,
+        createdAt: entry.created_at,
+        payloadJson: entry.payload_json,
+      });
+      entriesBySession.set(entry.session_id, bucket);
+    }
+    return transcripts.map((transcript) => ({
+      sessionId: transcript.session_id,
+      status: transcript.status,
+      createdAt: transcript.created_at,
+      archivedAt: transcript.archived_at,
+      cwd: transcript.cwd,
+      agentId: transcript.agent_id,
+      sessionType: transcript.session_type,
+      entries: entriesBySession.get(transcript.session_id) ?? [],
+    }));
+  } catch (error) {
+    try {
+      db.exec('ROLLBACK');
+    } catch {
+      // Preserve the snapshot error.
+    }
+    throw error;
+  }
+}
+
+async function writeIfChanged(path: string, contents: string): Promise<boolean> {
+  let existing: string | null = null;
+  try {
+    existing = await readFile(path, 'utf8');
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+  }
+  if (existing === contents) return false;
+  await writeTextAtomic(path, contents, { mode: 0o600, ensureDirMode: 0o700 });
+  return true;
+}
+
+export function resolveDefaultCtxHistoryExportDir(env: NodeJS.ProcessEnv = process.env): string {
+  return join(resolveStateDir(env), 'exports', 'ctx');
+}
+
+export async function exportCtxHistory(
+  db: DatabaseSync,
+  options: { outputDir?: string; env?: NodeJS.ProcessEnv } = {},
+): Promise<CtxHistoryExportResult> {
+  const outputDir = resolve(options.outputDir ?? resolveDefaultCtxHistoryExportDir(options.env));
+  const historyPath = join(outputDir, 'history.jsonl');
+  const manifestPath = join(outputDir, 'ctx-history-plugin.json');
+  const sessions = readSnapshot(db);
+  const history = buildCtxHistoryJsonl(sessions);
+  const manifest = buildCtxPluginManifest();
+
+  await mkdir(outputDir, { recursive: true, mode: 0o700 });
+  const historyChanged = await writeIfChanged(historyPath, history.contents);
+  const manifestChanged = await writeIfChanged(manifestPath, manifest);
+  return {
+    outputDir,
+    historyPath,
+    manifestPath,
+    sessionCount: sessions.length,
+    eventCount: history.eventCount,
+    changed: historyChanged || manifestChanged,
+  };
+}

--- a/src/history/ctx/format.ts
+++ b/src/history/ctx/format.ts
@@ -1,0 +1,342 @@
+import { createHash } from 'node:crypto';
+
+export const CTX_HISTORY_SCHEMA_VERSION = 'ctx-history-jsonl-v2';
+export const CTX_PROVIDER_KEY = 'xopc';
+export const CTX_SOURCE_ID = 'default';
+export const CTX_SOURCE_FORMAT = 'xopc-session-history-v1';
+
+const EVENT_INDEX_STRIDE = 65_536;
+const MAX_TEXT_CHUNK_BYTES = 1024 * 1024;
+const MAX_JSONL_LINE_BYTES = 16 * 1024 * 1024;
+
+export interface XopcHistorySession {
+  sessionId: string;
+  status: string;
+  createdAt: number;
+  archivedAt: number | null;
+  cwd: string;
+  agentId: string;
+  sessionType: string | null;
+  entries: XopcHistoryEntry[];
+}
+
+export interface XopcHistoryEntry {
+  entryId: string;
+  seq: number;
+  createdAt: number;
+  payloadJson: string;
+}
+
+interface NormalizedEvent {
+  eventType: string;
+  role?: 'user' | 'assistant' | 'tool';
+  text: string;
+  details?: Record<string, string | number | boolean | null>;
+}
+
+type JsonRecord = Record<string, unknown>;
+
+function asRecord(value: unknown): JsonRecord | null {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? value as JsonRecord
+    : null;
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}
+
+function timestamp(value: number, label: string): string {
+  const date = new Date(value);
+  if (!Number.isFinite(value) || Number.isNaN(date.getTime())) {
+    throw new Error(`Invalid ${label}: ${String(value)}`);
+  }
+  return date.toISOString();
+}
+
+function stringifyValue(value: unknown): string {
+  if (typeof value === 'string') return value;
+  if (value === undefined) return '';
+  return JSON.stringify(value) ?? '';
+}
+
+function textParts(content: unknown): string[] {
+  if (typeof content === 'string') return content.length > 0 ? [content] : [];
+  if (!Array.isArray(content)) return [];
+  return content.flatMap((block) => {
+    const record = asRecord(block);
+    return record?.type === 'text' && typeof record.text === 'string' && record.text.length > 0
+      ? [record.text]
+      : [];
+  });
+}
+
+function outputText(output: unknown): string {
+  if (typeof output === 'string') return output;
+  return textParts(output).join('');
+}
+
+function toolCallDetails(block: JsonRecord): NormalizedEvent | null {
+  const toolName = stringValue(block.name);
+  if (!toolName) return null;
+  const toolCallId = stringValue(block.id);
+  const argumentsText = stringifyValue(block.arguments);
+  const text = argumentsText ? `${toolName} ${argumentsText}` : toolName;
+  return {
+    eventType: 'tool_call',
+    role: 'assistant',
+    text,
+    details: {
+      tool_name: toolName,
+      ...(toolCallId ? { tool_call_id: toolCallId } : {}),
+    },
+  };
+}
+
+function normalizeAssistant(row: JsonRecord): NormalizedEvent[] {
+  if (typeof row.content === 'string') {
+    return row.content.length > 0
+      ? [{ eventType: 'message', role: 'assistant', text: row.content }]
+      : [];
+  }
+  if (!Array.isArray(row.content)) return [];
+
+  const events: NormalizedEvent[] = [];
+  for (const block of row.content) {
+    const record = asRecord(block);
+    if (!record) continue;
+    if (record.type === 'text' && typeof record.text === 'string' && record.text.length > 0) {
+      events.push({ eventType: 'message', role: 'assistant', text: record.text });
+      continue;
+    }
+    if (record.type === 'toolCall') {
+      const event = toolCallDetails(record);
+      if (event) events.push(event);
+    }
+  }
+  return events;
+}
+
+function normalizeToolResult(row: JsonRecord): NormalizedEvent[] {
+  const text = textParts(row.content).join('');
+  if (!text) return [];
+  const toolName = stringValue(row.toolName);
+  const toolCallId = stringValue(row.toolCallId);
+  return [{
+    eventType: 'tool_output',
+    role: 'tool',
+    text,
+    details: {
+      ...(toolName ? { tool_name: toolName } : {}),
+      ...(toolCallId ? { tool_call_id: toolCallId } : {}),
+      ...(typeof row.isError === 'boolean' ? { is_error: row.isError } : {}),
+    },
+  }];
+}
+
+function normalizeBashExecution(row: JsonRecord): NormalizedEvent[] {
+  const command = stringValue(row.command);
+  if (!command) return [];
+  const events: NormalizedEvent[] = [{
+    eventType: 'command_started',
+    role: 'user',
+    text: command,
+  }];
+  const output = outputText(row.output);
+  if (output) {
+    events.push({ eventType: 'command_output', role: 'tool', text: output });
+  }
+  events.push({
+    eventType: 'command_finished',
+    role: 'tool',
+    text: row.exitCode == null ? 'Command finished' : `Command exited with code ${String(row.exitCode)}`,
+    details: {
+      ...(typeof row.exitCode === 'number' ? { exit_code: row.exitCode } : {}),
+      ...(typeof row.signal === 'string' ? { signal: row.signal } : {}),
+      ...(typeof row.truncated === 'boolean' ? { truncated: row.truncated } : {}),
+    },
+  });
+  return events;
+}
+
+function normalizeStoredRow(row: JsonRecord): NormalizedEvent[] {
+  if (row.kind === 'context' || row.role === 'system') return [];
+  if (row.type === 'compaction' && typeof row.summary === 'string' && row.summary.length > 0) {
+    return [{ eventType: 'summary', role: 'assistant', text: row.summary }];
+  }
+  if (
+    (row.role === 'branchSummary' || row.role === 'compactionSummary')
+    && typeof row.summary === 'string'
+    && row.summary.length > 0
+  ) {
+    return [{ eventType: 'summary', role: 'assistant', text: row.summary }];
+  }
+  if (row.role === 'bashExecution') return normalizeBashExecution(row);
+  if (row.role === 'custom' || row.type === 'custom_message') {
+    if (row.display === false) return [];
+    return textParts(row.content).map((text) => ({ eventType: 'message', role: 'user', text }));
+  }
+  if (row.role === 'user') {
+    return textParts(row.content).map((text) => ({ eventType: 'message', role: 'user', text }));
+  }
+  if (row.role === 'assistant') return normalizeAssistant(row);
+  if (row.role === 'toolResult' || row.role === 'tool') return normalizeToolResult(row);
+  return [];
+}
+
+function splitTextByUtf8Bytes(text: string): string[] {
+  if (Buffer.byteLength(text, 'utf8') <= MAX_TEXT_CHUNK_BYTES) return [text];
+  const chunks: string[] = [];
+  let start = 0;
+  while (start < text.length) {
+    let low = start + 1;
+    let high = text.length;
+    let end = low;
+    while (low <= high) {
+      const middle = Math.floor((low + high) / 2);
+      if (Buffer.byteLength(text.slice(start, middle), 'utf8') <= MAX_TEXT_CHUNK_BYTES) {
+        end = middle;
+        low = middle + 1;
+      } else {
+        high = middle - 1;
+      }
+    }
+    const previous = text.charCodeAt(end - 1);
+    const next = text.charCodeAt(end);
+    if (previous >= 0xd800 && previous <= 0xdbff && next >= 0xdc00 && next <= 0xdfff) {
+      end -= 1;
+    }
+    chunks.push(text.slice(start, end));
+    start = end;
+  }
+  return chunks;
+}
+
+function stableEventId(sessionId: string, entryId: string, eventOffset: number): string {
+  const digest = createHash('sha256')
+    .update(sessionId)
+    .update('\0')
+    .update(entryId)
+    .update('\0')
+    .update(String(eventOffset))
+    .digest('hex');
+  return `xopc:${digest}`;
+}
+
+function serializeRecord(record: JsonRecord): string {
+  const line = JSON.stringify(record);
+  const size = Buffer.byteLength(line, 'utf8');
+  if (size > MAX_JSONL_LINE_BYTES) {
+    throw new Error(`ctx history record exceeds 16 MiB (${size} bytes)`);
+  }
+  return line;
+}
+
+function sessionRecord(session: XopcHistorySession): JsonRecord {
+  const active = session.status === 'active';
+  return {
+    record_type: 'session',
+    source_id: CTX_SOURCE_ID,
+    provider_session_id: session.sessionId,
+    started_at: timestamp(session.createdAt, `session timestamp for ${session.sessionId}`),
+    external_agent_id: session.agentId,
+    cwd: session.cwd,
+    ...(session.archivedAt === null
+      ? {}
+      : { ended_at: timestamp(session.archivedAt, `session end timestamp for ${session.sessionId}`) }),
+    status: active ? 'active' : 'completed',
+    agent_scope: session.sessionType === 'workflow-subagent' ? 'subagent' : 'primary',
+  };
+}
+
+function entryRecords(session: XopcHistorySession, entry: XopcHistoryEntry): JsonRecord[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(entry.payloadJson);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Invalid transcript payload for entry ${entry.entryId}: ${message}`);
+  }
+  const row = asRecord(parsed);
+  if (!row) throw new Error(`Transcript payload for entry ${entry.entryId} is not an object`);
+
+  const occurredAt = timestamp(entry.createdAt, `entry timestamp for ${entry.entryId}`);
+  const records: JsonRecord[] = [];
+  let offset = 0;
+  for (const event of normalizeStoredRow(row)) {
+    const chunks = splitTextByUtf8Bytes(event.text);
+    for (let chunkIndex = 0; chunkIndex < chunks.length; chunkIndex += 1) {
+      if (offset >= EVENT_INDEX_STRIDE) {
+        throw new Error(`Transcript entry ${entry.entryId} expands to too many ctx events`);
+      }
+      const eventIndex = entry.seq * EVENT_INDEX_STRIDE + offset;
+      if (!Number.isSafeInteger(eventIndex) || eventIndex < 0) {
+        throw new Error(`Transcript sequence is outside the supported range: ${entry.seq}`);
+      }
+      records.push({
+        record_type: 'event',
+        source_id: CTX_SOURCE_ID,
+        provider_session_id: session.sessionId,
+        event_index: eventIndex,
+        event_id: stableEventId(session.sessionId, entry.entryId, offset),
+        occurred_at: occurredAt,
+        event_type: event.eventType,
+        ...(event.role ? { role: event.role } : {}),
+        payload: {
+          text: chunks[chunkIndex],
+          ...event.details,
+          ...(chunks.length > 1 ? { chunk_index: chunkIndex, chunk_count: chunks.length } : {}),
+        },
+      });
+      offset += 1;
+    }
+  }
+  return records;
+}
+
+export function buildCtxHistoryJsonl(sessions: XopcHistorySession[]): {
+  contents: string;
+  eventCount: number;
+} {
+  const lines = [
+    serializeRecord({
+      record_type: 'manifest',
+      schema_version: CTX_HISTORY_SCHEMA_VERSION,
+      producer: 'xopc',
+    }),
+    serializeRecord({
+      record_type: 'source',
+      source_id: CTX_SOURCE_ID,
+      provider_key: CTX_PROVIDER_KEY,
+      source_format: CTX_SOURCE_FORMAT,
+    }),
+  ];
+  let eventCount = 0;
+  for (const session of sessions) {
+    lines.push(serializeRecord(sessionRecord(session)));
+    for (const entry of session.entries) {
+      const records = entryRecords(session, entry);
+      eventCount += records.length;
+      lines.push(...records.map(serializeRecord));
+    }
+  }
+  return { contents: `${lines.join('\n')}\n`, eventCount };
+}
+
+export function buildCtxPluginManifest(): string {
+  return `${JSON.stringify({
+    schema_version: 1,
+    name: 'xopc',
+    display_name: 'XOPC history',
+    version: '1.0.0',
+    history_sources: [{
+      id: CTX_SOURCE_ID,
+      provider_key: CTX_PROVIDER_KEY,
+      source_id: CTX_SOURCE_ID,
+      source_format: CTX_SOURCE_FORMAT,
+      path: 'history.jsonl',
+      enabled: true,
+      refresh: 'manual',
+    }],
+  }, null, 2)}\n`;
+}


### PR DESCRIPTION
## Summary

- add `xopc history export ctx` as a provider-owned `ctx-history-jsonl-v2` exporter
- emit a durable JSONL source plus a ctx history-source plugin manifest under the XOPC state directory
- preserve reset generations and searchable tool/command activity while excluding hidden context, system prompts, reasoning, invisible extension messages, and deleted sessions
- document the workflow in English and Chinese

This follows the integration direction from ctxrs/ctx#839 and keeps the XOPC SQLite schema mapping inside XOPC.

## Related issues

- Follow-up to ctxrs/ctx#839

## Test plan

- [x] targeted history and CLI manifest tests: 9 passed
- [x] `pnpm test` — GitHub CI full suite passed
- [x] `pnpm run lint`
- [x] `pnpm run depcheck` — 0 violations
- [x] `pnpm run build`
- [x] `pnpm run docs:build`
- [x] `pnpm run test:startup:imports`
- [x] manual XOPC SQLite → export → ctx plugin import → `ctx search --history-source xopc/default` E2E

Local full-suite verification completed 5604/5606 before two unrelated timing-sensitive tests failed under parallel load; both passed when rerun together in isolation (24/24). The GitHub CI Test job subsequently passed the complete suite.

## Architecture / dependency-cruiser

The exporter is a leaf integration over the existing SQLite and atomic-file primitives. It adds no dependency violations or cycles.

## Notes

- Export is explicit; there is no background exporter or ctx-core adapter.
- Output is deterministic and unchanged files are not rewritten.
- The JSONL and plugin manifest are written atomically with private file permissions; newly created output directories use private permissions on POSIX systems.
- No configuration migration or legacy format alias is introduced.