### PR TITLE
fix(ci): retry transient Electron packaging failures

### DIFF
--- a/.github/workflows/electron-build.yml
+++ b/.github/workflows/electron-build.yml
@@ -171,43 +171,12 @@ jobs:
           # electron-builder.mjs hides pnpm workspace markers + verifies asar node_modules size on success.
           # macOS: build architectures sequentially to avoid DMG temp file conflicts
           if [[ "${{ matrix.os }}" == "macos-latest" ]]; then
-            build_macos_arch() {
-              local arch="$1"
-              local attempt=1
-              local max_attempts=3
-              local log_file
-
-              while (( attempt <= max_attempts )); do
-                log_file="$(mktemp)"
-                if node scripts/electron-builder.mjs --mac "--${arch}" 2>&1 | tee "$log_file"; then
-                  rm -f "$log_file"
-                  return 0
-                fi
-
-                if ! grep -Eqi '503 Slow Down|code: serviceUnavailable' "$log_file"; then
-                  rm -f "$log_file"
-                  return 1
-                fi
-                rm -f "$log_file"
-
-                if (( attempt == max_attempts )); then
-                  echo "❌ Apple notarization remained rate-limited after ${max_attempts} attempts"
-                  return 1
-                fi
-
-                local delay_seconds=$((attempt * 30))
-                echo "⚠️ Apple notarization upload was rate-limited; retrying ${arch} build in ${delay_seconds}s (attempt ${attempt}/${max_attempts})"
-                sleep "$delay_seconds"
-                ((attempt += 1))
-              done
-            }
-
             echo "Building macOS x64..."
-            build_macos_arch x64
+            bash scripts/build-electron-with-retry.sh --mac --x64
             echo "Building macOS arm64..."
-            build_macos_arch arm64
+            bash scripts/build-electron-with-retry.sh --mac --arm64
           else
-            node scripts/electron-builder.mjs ${{ matrix.electron_builder_args }}
+            bash scripts/build-electron-with-retry.sh ${{ matrix.electron_builder_args }}
           fi
 
       - name: Verify artifacts

--- a/scripts/__tests__/build-electron-with-retry.test.ts
+++ b/scripts/__tests__/build-electron-with-retry.test.ts
@@ -1,0 +1,105 @@
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { delimiter, join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+describe('build-electron-with-retry', () => {
+  const roots: string[] = [];
+
+  afterEach(() => {
+    for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+  });
+
+  function runBuild(failures: number, error: string, args = ['--linux', 'appimage', '--arm64']) {
+    const root = mkdtempSync(join(tmpdir(), 'xopc-electron-retry-'));
+    roots.push(root);
+    writeFileSync(
+      join(root, 'node'),
+      `#!/usr/bin/env bash
+set -euo pipefail
+state="$XOPC_RETRY_TEST_ROOT"
+count=0
+if [[ -f "$state/count" ]]; then count="$(cat "$state/count")"; fi
+count=$((count + 1))
+echo "$count" > "$state/count"
+printf '%s\\n' "$@" > "$state/args"
+if (( count <= XOPC_RETRY_TEST_FAILURES )); then
+  echo "$XOPC_RETRY_TEST_ERROR" >&2
+  exit 23
+fi
+echo 'Packaging complete'
+`,
+      { mode: 0o755 },
+    );
+    writeFileSync(
+      join(root, 'sleep'),
+      '#!/usr/bin/env bash\necho "$1" >> "$XOPC_RETRY_TEST_ROOT/delays"\n',
+      { mode: 0o755 },
+    );
+
+    const result = spawnSync('bash', ['scripts/build-electron-with-retry.sh', ...args], {
+      cwd: process.cwd(),
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        PATH: `${root}${delimiter}${process.env.PATH}`,
+        XOPC_RETRY_TEST_ROOT: root,
+        XOPC_RETRY_TEST_FAILURES: String(failures),
+        XOPC_RETRY_TEST_ERROR: error,
+      },
+      timeout: 10_000,
+    });
+    expect(result.error).toBeUndefined();
+    return {
+      ...result,
+      attempts: Number(readFileSync(join(root, 'count'), 'utf8')),
+      args: readFileSync(join(root, 'args'), 'utf8').trim().split('\n'),
+      delays: existsSync(join(root, 'delays'))
+        ? readFileSync(join(root, 'delays'), 'utf8').trim().split('\n')
+        : [],
+    };
+  }
+
+  it('builds once on success and forwards each argument intact', () => {
+    const args = ['--linux', 'appimage', '--arm64', '--config.productName=Test App'];
+    const result = runBuild(0, '', args);
+    expect(result.status).toBe(0);
+    expect(result.attempts).toBe(1);
+    expect(result.delays).toEqual([]);
+    expect(result.args).toEqual(['scripts/electron-builder.mjs', ...args]);
+  });
+
+  it.each([
+    'ReadError: The server aborted pending request',
+    'read ECONNRESET',
+    'connect ETIMEDOUT',
+    'getaddrinfo EAI_AGAIN',
+    'socket hang up',
+    '503 Slow Down',
+    'code: serviceUnavailable',
+  ])('retries a transient failure: %s', (error) => {
+    const result = runBuild(1, error);
+    expect(result.status).toBe(0);
+    expect(result.attempts).toBe(2);
+    expect(result.delays).toEqual(['30']);
+    expect(result.stdout).toContain(error);
+    expect(result.stdout).toContain('Packaging complete');
+  });
+
+  it('stops after three failed attempts and preserves the build exit code', () => {
+    const result = runBuild(3, 'ReadError: The server aborted pending request');
+    expect(result.status).toBe(23);
+    expect(result.attempts).toBe(3);
+    expect(result.delays).toEqual(['30', '60']);
+    expect(result.stdout).toContain('failed after 3 attempts');
+  });
+
+  it('fails immediately for build errors', () => {
+    const result = runBuild(3, 'Invalid configuration object');
+    expect(result.status).toBe(23);
+    expect(result.attempts).toBe(1);
+    expect(result.delays).toEqual([]);
+  });
+});

--- a/scripts/build-electron-with-retry.sh
+++ b/scripts/build-electron-with-retry.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Retry transient download and notarization failures in CI; keep build errors fatal.
+set -euo pipefail
+
+max_attempts=3
+log_file="$(mktemp)"
+trap 'rm -f "$log_file"' EXIT
+
+for ((attempt = 1; attempt <= max_attempts; attempt++)); do
+  if node scripts/electron-builder.mjs "$@" 2>&1 | tee "$log_file"; then
+    exit 0
+  else
+    build_status=${PIPESTATUS[0]}
+  fi
+
+  # A failed log pipe must not turn a successful builder exit into a successful job.
+  if (( build_status == 0 )); then
+    exit 1
+  fi
+  if ! grep -Eqi 'The server aborted pending request|ECONNRESET|ETIMEDOUT|EAI_AGAIN|socket hang up|503 Slow Down|code: serviceUnavailable' "$log_file"; then
+    exit "$build_status"
+  fi
+  if (( attempt == max_attempts )); then
+    echo "Electron packaging failed after ${max_attempts} attempts."
+    exit "$build_status"
+  fi
+
+  delay_seconds=$((attempt * 30))
+  echo "Transient Electron packaging failure; retrying in ${delay_seconds}s (attempt ${attempt}/${max_attempts})."
+  sleep "$delay_seconds"
+done


### PR DESCRIPTION
## Summary

The v0.0.234 Electron release stopped on Linux x64 when an AppImage download failed with `ReadError: The server aborted pending request`. All platforms now use a shared packaging wrapper that retries recognized transient network and Apple notarization errors up to three times, waiting 30 and 60 seconds between attempts. Other build failures still stop immediately and retain their exit code; macOS architectures remain sequential.

## Related issues

Failed build: https://github.com/xopcai/xopc/actions/runs/33697087811

## Test plan

- [x] `pnpm exec vitest run scripts/__tests__/build-electron-with-retry.test.ts` — 10 tests passed, covering success, argument forwarding, transient errors, backoff, retry exhaustion, and immediate build failure.
- [x] `bash -n scripts/build-electron-with-retry.sh`
- [x] Parsed workflow YAML and syntax-checked the extracted Electron build step with Bash.
- [x] `git diff --check`
- [x] CI architecture, lint/typecheck, React Doctor, and build checks passed (no application imports changed).
- [x] Original v0.0.234 failed job rerun (attempt 2) succeeded; all five platform jobs and Publish GitHub Release passed. All 13 release assets are uploaded: https://github.com/xopcai/xopc/releases/tag/v0.0.234
- [ ] Full CI test suite is still running.
